### PR TITLE
Disable RC4 and SSL3

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/tls"
 	"flag"
 	"log"
 	"net"
@@ -83,7 +84,24 @@ func main() {
 		handler = &SubnetRoute{handler, authenticated, ipNet}
 	}
 
-	err = http.ListenAndServeTLS(listen, cert, key, handler)
+	config := &tls.Config{
+		MinVersion: tls.VersionTLS10,
+		CipherSuites: []uint16{
+			// Note: RC4 is removed.
+			tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+			tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+			tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+			tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		},
+	}
+	server := &http.Server{Addr: listen, Handler: handler, TLSConfig: config}
+	err = server.ListenAndServeTLS(cert, key)
 	if err != nil {
 		log.Fatalln("http.ListenAndServeTLS:", err)
 	}


### PR DESCRIPTION
Previously the proxy would only score a C on the Qualsys SSL labs server test. With this change, it scores an A-, which I think is the highest it's possible for a go binary to get due to a lack of forward secrecy support for some ancient browsers (e.g, IE 7-10 on Win7, IE10 on Win mobile 8, java 6u45, openssl 0.9.8y, android 2.3.7).