### PR TITLE
Apply auth handler when subnet not supplied

### DIFF
--- a/main.go
+++ b/main.go
@@ -82,6 +82,8 @@ func main() {
 
 	if subnet != "" {
 		handler = &SubnetRoute{handler, authenticated, ipNet}
+	} else {
+		handler = authenticated
 	}
 
 	config := &tls.Config{


### PR DESCRIPTION
There was a path through the code which did not check the
authenticated handler, this plugs that gap.

I don't believe this has any consequences yet, because there
isn't anywhere we use auth without specifying a subnet.