### PR TITLE
Add a -tls flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ func (s *SubnetRoute) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func main() {
 	var (
 		listen, cert, key, htpasswdFile, where, subnet string
+		tlsFlag                                        bool
 	)
 	flag.StringVar(&listen, "listen", ":443", "Bind address to listen on")
 	flag.StringVar(&key, "key", "/etc/ssl/private/key.pem", "Path to PEM key")
@@ -45,6 +46,7 @@ func main() {
 	flag.StringVar(&htpasswdFile, "htpasswdFile", "", "File to use for htpasswd protected access")
 	flag.StringVar(&where, "where", "http://localhost:80", "Place to forward connections to")
 	flag.StringVar(&subnet, "subnet", "", "If specified, subnet which can circumvent htpasswd authorization")
+	flag.BoolVar(&tlsFlag, "tls", true, "accept HTTPS connections")
 	flag.Parse()
 
 	url, err := url.Parse(where)
@@ -104,9 +106,17 @@ func main() {
 			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 		},
 	}
+
 	server := &http.Server{Addr: listen, Handler: handler, TLSConfig: config}
-	err = server.ListenAndServeTLS(cert, key)
-	if err != nil {
-		log.Fatalln("http.ListenAndServeTLS:", err)
+	if tlsFlag {
+		err = server.ListenAndServeTLS(cert, key)
+		if err != nil {
+			log.Fatalln("http.ListenAndServeTLS:", err)
+		}
+	} else {
+		err = server.ListenAndServe()
+		if err != nil {
+			log.Fatalln("http.ListenAndServe:", err)
+		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -110,13 +110,10 @@ func main() {
 	server := &http.Server{Addr: listen, Handler: handler, TLSConfig: config}
 	if tlsFlag {
 		err = server.ListenAndServeTLS(cert, key)
-		if err != nil {
-			log.Fatalln("http.ListenAndServeTLS:", err)
-		}
 	} else {
 		err = server.ListenAndServe()
-		if err != nil {
-			log.Fatalln("http.ListenAndServe:", err)
-		}
-	}
+        }
+        if err != nil {
+                log.Fatalln(err)
+        }
 }


### PR DESCRIPTION
The reason we add this flag is so that we can disable TLS. Useful in testing environments where we don't want to have a key for serving HTTPS.