### PR TITLE
Delay upgraded incoming connection

### DIFF
--- a/wscapableproxy.go
+++ b/wscapableproxy.go
@@ -108,8 +108,8 @@ func (p *WebsocketCapableReverseProxy) ServeWebsocket(w http.ResponseWriter, r *
 			}
 		} else {
 			log.Printf("outbound websocket dial error, err: %v", err)
-			w.WriteHeader(503)
-			fmt.Fprintf(w, "outbound websocket dial error, err: %v", err)
+			w.WriteHeader(502)
+			fmt.Fprintln(w, "Bad Gateway")
 		}
 		return
 	}

--- a/wscapableproxy.go
+++ b/wscapableproxy.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"io"
 	"log"
 	"net"
@@ -108,8 +107,7 @@ func (p *WebsocketCapableReverseProxy) ServeWebsocket(w http.ResponseWriter, r *
 			}
 		} else {
 			log.Printf("outbound websocket dial error, err: %v", err)
-			w.WriteHeader(502)
-			fmt.Fprintln(w, "Bad Gateway")
+			http.Error(w, "502 Bad Gateway", http.StatusBadGateway)
 		}
 		return
 	}


### PR DESCRIPTION
We avoid upgrading the incoming connection until we've
established and upgraded the outgoing connection. This allows us
to send HTTP errors back to the client when the outgoing
connection fails for some reason.