### PR TITLE
Remove wait for reader goroutine

### DIFF
--- a/wscapableproxy.go
+++ b/wscapableproxy.go
@@ -121,14 +121,10 @@ func (p *WebsocketCapableReverseProxy) ServeWebsocket(w http.ResponseWriter, r *
 	}
 	defer inConn.Close()
 
-	finish := make(chan struct{})
-	defer func() { <-finish }()
-
 	rawIn := inConn.UnderlyingConn()
 	rawOut := outConn.UnderlyingConn()
 
 	go func() {
-		defer close(finish)
 		_, _ = io.Copy(rawOut, rawIn)
 	}()
 


### PR DESCRIPTION
It used to be that we would not call inConn.Close() until rawIn was
closed. This caused the bug in #11, so the blocking read has been
removed.

Fixes #11.