### PR TITLE
Add better error message for backend errors

### DIFF
--- a/wscapableproxy.go
+++ b/wscapableproxy.go
@@ -41,11 +41,10 @@ type WebsocketCapableReverseProxy struct {
 	target *url.URL
 }
 
-func NewWebsocketCapableReverseProxy(url *url.URL) *WebsocketCapableReverseProxy {
-	return &WebsocketCapableReverseProxy{
-		httputil.NewSingleHostReverseProxy(url),
-		url,
-	}
+func NewWebsocketCapableReverseProxy(
+	proxy *httputil.ReverseProxy, url *url.URL,
+) *WebsocketCapableReverseProxy {
+	return &WebsocketCapableReverseProxy{proxy, url}
 }
 
 func (p *WebsocketCapableReverseProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Currently, if there is an error connecting to the backend, the proxy gives a blank
response to the client. It is perhaps more helpful if it gives a sensible error
message. Here is the new one:

![screenshot from 2015-06-04 23 19 50](https://cloud.githubusercontent.com/assets/438648/7995745/fa5a4e50-0b10-11e5-8c0d-e3fc6a7e5220.png)