### PR TITLE
Add -behind-tcp-proxy to accept PROXY'd remotes

### DIFF
--- a/proxyprotocol/http.go
+++ b/proxyprotocol/http.go
@@ -1,0 +1,82 @@
+package proxyprotocol
+
+import (
+	"crypto/tls"
+	"net"
+	"net/http"
+	"time"
+)
+
+// Copied verbatim from net/http's server.go.
+// tcpKeepAliveListener sets TCP keep-alive timeouts on accepted
+// connections. It's used by ListenAndServe and ListenAndServeTLS so
+// dead TCP connections (e.g. closing laptop mid-download) eventually
+// go away.
+type tcpKeepAliveListener struct {
+	*net.TCPListener
+}
+
+func (ln tcpKeepAliveListener) Accept() (c net.Conn, err error) {
+	tc, err := ln.AcceptTCP()
+	if err != nil {
+		return
+	}
+	tc.SetKeepAlive(true)
+	tc.SetKeepAlivePeriod(3 * time.Minute)
+	return tc, nil
+}
+
+func BehindTCPProxyListenAndServeTLS(srv *http.Server, certFile, keyFile string) error {
+	// Begin copied verbatim from net/http
+	addr := srv.Addr
+	if addr == "" {
+		addr = ":https"
+	}
+	config := &tls.Config{}
+	if srv.TLSConfig != nil {
+		*config = *srv.TLSConfig
+	}
+	if config.NextProtos == nil {
+		config.NextProtos = []string{"http/1.1"}
+	}
+
+	var err error
+	config.Certificates = make([]tls.Certificate, 1)
+	config.Certificates[0], err = tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return err
+	}
+
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
+	// End copied verbatim from net/http
+
+	// Wrap the listener with one understanding the PROXY protocol
+	var listener net.Listener
+	listener = tcpKeepAliveListener{ln.(*net.TCPListener)}
+	listener = NewListener(listener)
+	listener = tls.NewListener(listener, config)
+	return srv.Serve(listener)
+}
+
+// ListenAndServe listens on the TCP network address srv.Addr and then
+// calls Serve to handle requests on incoming connections.  If
+// srv.Addr is blank, ":http" is used.
+func BehindTCPProxyListenAndServe(srv *http.Server) error {
+	// Begin copied verbatim from net/http
+	addr := srv.Addr
+	if addr == "" {
+		addr = ":http"
+	}
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
+	// End copied verbatim from net/http
+
+	// Wrap the listener with one understanding the PROXY protocol
+	listener := NewListener(tcpKeepAliveListener{ln.(*net.TCPListener)})
+	return srv.Serve(listener)
+}

--- a/proxyprotocol/proxy.go
+++ b/proxyprotocol/proxy.go
@@ -1,0 +1,133 @@
+package proxyprotocol
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"log"
+	"net"
+	"sync"
+
+	"github.com/scraperwiki/tiny-ssl-reverse-proxy/proxyprotocol/proxyline"
+)
+
+type Accept struct {
+	c   net.Conn
+	err error
+}
+
+type Listener struct {
+	net.Listener
+	wg      sync.WaitGroup
+	accepts <-chan Accept
+	done    chan<- struct{}
+}
+
+func NewListener(underlying net.Listener) net.Listener {
+	done := make(chan struct{})
+	accepts := make(chan Accept, 10)
+
+	l := &Listener{
+		underlying,
+		sync.WaitGroup{},
+		accepts,
+		done,
+	}
+
+	l.wg.Add(1)
+	go func() {
+		defer l.wg.Done()
+		for {
+			// underlying
+			c, err := underlying.Accept()
+			if err != nil {
+				accepts <- Accept{c, err}
+				continue
+			}
+
+			// Asynchronously process a PROXY instruction before passing it off
+			// to the consumer's accept loop.
+			go func() {
+				// Process the "PROXY" string
+				buf := bufio.NewReader(c)
+				p, err := proxyline.ConsumeProxyLine(buf)
+				if err != nil {
+					log.Printf("proxyprotocol failed to parse PROXY header: "+
+						"%v", err)
+					// Failed to read the proxy string, drop the connection.
+
+					_ = c.Close() // Ignore the error.
+					return
+				}
+
+				// Wrap the connection with a reader which first reads whatever
+				// remains in the buffer, followed by the rest of the
+				// connection.
+				// Because we're using buf.Buffered(), can ignore the error.
+				bufbytes, _ := buf.Peek(buf.Buffered())
+				buffered := bytes.NewReader(bufbytes)
+				r := io.MultiReader(buffered, c)
+
+				wrapped := &Conn{Reader: r, Conn: c}
+				if p != nil {
+					ra := &net.TCPAddr{p.SrcAddr.IP, p.SrcPort, p.SrcAddr.Zone}
+					la := &net.TCPAddr{p.DstAddr.IP, p.DstPort, p.DstAddr.Zone}
+					wrapped.remoteAddr = ra
+					wrapped.localAddr = la
+				}
+
+				accepts <- Accept{wrapped, err}
+			}()
+
+			select {
+			case <-done:
+				return
+			default:
+			}
+		}
+	}()
+
+	return l
+}
+
+func (l *Listener) Accept() (net.Conn, error) {
+	accept, ok := <-l.accepts
+	if !ok {
+		return nil, io.ErrClosedPipe
+	}
+
+	return accept.c, accept.err
+}
+
+func (l *Listener) Close() error {
+	close(l.done)
+	err := l.Close()
+	l.wg.Wait()
+	return err
+}
+
+type Conn struct {
+	io.Reader
+	net.Conn
+	remoteAddr, localAddr net.Addr
+}
+
+func (c *Conn) Read(bs []byte) (int, error) {
+	return c.Reader.Read(bs)
+}
+
+// Return the specified local addr, if there is one.
+func (c *Conn) LocalAddr() net.Addr {
+	if c.localAddr != nil {
+		return c.localAddr
+	}
+	return c.Conn.LocalAddr()
+}
+
+// Return the specified remote addr, if there is one.
+func (c *Conn) RemoteAddr() net.Addr {
+	if c.remoteAddr != nil {
+		return c.remoteAddr
+	}
+	return c.Conn.RemoteAddr()
+}

--- a/proxyprotocol/proxyline/LICENSE
+++ b/proxyprotocol/proxyline/LICENSE
@@ -1,0 +1,15 @@
+This uses code from https://github.com/racker/go-proxy-protocol
+
+Copyright 2013 Rackspace
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/proxyprotocol/proxyline/parser.go
+++ b/proxyprotocol/proxyline/parser.go
@@ -1,0 +1,140 @@
+/**
+ *  Copyright 2013 Rackspace
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+// Packet proxyProtocol implements Proxy Protocol parser and writer.
+package proxyline
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+)
+
+// INET protocol and family
+const (
+	TCP4    = "TCP4"    // TCP over IPv4
+	TCP6    = "TCP6"    // TCP over IPv6
+	UNKNOWN = "UNKNOWN" // Unsupported or unknown protocols
+)
+
+var (
+	InvalidProxyLine   = errors.New("Invalid proxy line")
+	UnmatchedIPAddress = errors.New("IP address(es) unmatched with protocol")
+	InvalidPortNum     = errors.New(fmt.Sprintf("Invalid port number parsed. (expected [%d..%d])", _port_lower, _port_upper))
+)
+
+var (
+	_proxy      = []byte{'P', 'R', 'O', 'X', 'Y'}
+	_CRLF       = "\r\n"
+	_sep        = " "
+	_port_lower = 0
+	_port_upper = 65535
+)
+
+type ProxyLine struct {
+	Protocol string
+	SrcAddr  *net.IPAddr
+	DstAddr  *net.IPAddr
+	SrcPort  int
+	DstPort  int
+}
+
+// ConsumeProxyLine looks for PROXY line in the reader and try to parse it if found.
+//
+// If first 5 bytes in reader is "PROXY", the function reads one line (until first '\n') from reader and try to parse it as ProxyLine. A newly allocated ProxyLine is returned if parsing secceeds. If parsing fails, a nil and an error is returned;
+//
+// If first 5 bytes in reader is not "PROXY", the function simply returns (nil, nil), leaving reader intact (nothing from reader is consumed).
+//
+// If the being parsed PROXY line is using an unknown protocol, ConsumeProxyLine parses remaining fields as same syntax as a supported protocol assuming IP is used in layer 3, and reports error if failed.
+func ConsumeProxyLine(reader *bufio.Reader) (*ProxyLine, error) {
+	word, err := reader.Peek(5)
+	if !bytes.Equal(word, _proxy) {
+		return nil, nil
+	}
+	line, err := reader.ReadString('\n')
+	if !strings.HasSuffix(line, _CRLF) {
+		return nil, InvalidProxyLine
+	}
+	tokens := strings.Split(line[:len(line)-2], _sep)
+	ret := new(ProxyLine)
+	if len(tokens) < 6 {
+		return nil, InvalidProxyLine
+	}
+	switch tokens[1] {
+	case TCP4:
+		ret.Protocol = TCP4
+	case TCP6:
+		ret.Protocol = TCP6
+	default:
+		ret.Protocol = UNKNOWN
+	}
+	ret.SrcAddr, err = parseIPAddr(ret.Protocol, tokens[2])
+	if err != nil {
+		return nil, err
+	}
+	ret.DstAddr, err = parseIPAddr(ret.Protocol, tokens[3])
+	if err != nil {
+		return nil, err
+	}
+	ret.SrcPort, err = parsePortNumber(tokens[4])
+	if err != nil {
+		return nil, err
+	}
+	ret.DstPort, err = parsePortNumber(tokens[5])
+	if err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+// WriteProxyLine formats p as valid PROXY line into w
+func (p *ProxyLine) WriteProxyLine(w io.Writer) (err error) {
+	_, err = fmt.Fprintf(w, "PROXY %s %s %s %d %d\r\n", p.Protocol, p.SrcAddr.String(), p.DstAddr.String(), p.SrcPort, p.DstPort)
+	return
+}
+
+func parsePortNumber(portStr string) (port int, err error) {
+	port, err = strconv.Atoi(portStr)
+	if err == nil {
+		if port < _port_lower || port > _port_upper {
+			err = InvalidPortNum
+		}
+	}
+	return
+}
+
+func parseIPAddr(protocol string, addrStr string) (addr *net.IPAddr, err error) {
+	proto := "ip"
+	if protocol == TCP4 {
+		proto = "ip4"
+	} else if protocol == TCP6 {
+		proto = "ip6"
+	}
+	addr, err = net.ResolveIPAddr(proto, addrStr)
+	if err == nil {
+		tryV4 := addr.IP.To4()
+		if (protocol == TCP4 && tryV4 == nil) || (protocol == TCP6 && tryV4 != nil) {
+			err = UnmatchedIPAddress
+		}
+	}
+	return
+}

--- a/proxyprotocol/proxyline/parser_test.go
+++ b/proxyprotocol/proxyline/parser_test.go
@@ -1,0 +1,74 @@
+package proxyline
+
+import (
+	"bufio"
+	"net"
+	"strings"
+	"testing"
+)
+
+var (
+	fixtureTCP4 = "PROXY TCP4 127.0.0.1 127.0.0.1 65533 65533\r\n"
+	fixtureTCP6 = "PROXY TCP6 2001:4801:7817:72:d4d9:211d:ff10:1631 2001:4801:7817:72:d4d9:211d:ff10:1631 65533 65533\r\n"
+
+	v4addr, _ = net.ResolveIPAddr("ip", "127.0.0.1")
+	v6addr, _ = net.ResolveIPAddr("ip", "2001:4801:7817:72:d4d9:211d:ff10:1631")
+	pTCP4     = &ProxyLine{Protocol: TCP4, SrcAddr: v4addr, DstAddr: v4addr, SrcPort: 65533, DstPort: 65533}
+	pTCP6     = &ProxyLine{Protocol: TCP6, SrcAddr: v6addr, DstAddr: v6addr, SrcPort: 65533, DstPort: 65533}
+
+	invalidProxyLines = []string{
+		"PROXY TCP4 127.0.0.1 127.0.0.1 65533 65533", // no CRLF
+		"PROXY \r\n",                                 // not enough fields
+		"PROXY TCP6 127.0.0.1 127.0.0.1 65533 65533\r\n,",                                                        // unmatched protocol addr
+		"PROXY TCP4 2001:4801:7817:72:d4d9:211d:ff10:1631 2001:4801:7817:72:d4d9:211d:ff10:1631 65533 65533\r\n", // unmatched protocol addr
+	}
+	noneProxyLine = "There is no spoon."
+)
+
+func TestParseTCP4(t *testing.T) {
+	reader := bufio.NewReader(strings.NewReader(fixtureTCP4))
+	p, err := ConsumeProxyLine(reader)
+	if err != nil {
+		t.Fatalf("Parsing TCP4 failed: %v\n", err)
+	}
+	if !p.EqualTo(pTCP4) {
+		t.Fatalf("Expected ProxyLine %v, got %v\n", pTCP4, p)
+	}
+}
+
+func TestParseTCP6(t *testing.T) {
+	reader := bufio.NewReader(strings.NewReader(fixtureTCP6))
+	p, err := ConsumeProxyLine(reader)
+	if err != nil {
+		t.Fatalf("Parsing TCP6 failed: %v\n", err)
+	}
+	if !p.EqualTo(pTCP6) {
+		t.Fatalf("Expected ProxyLine %v, got %v\n", pTCP6, p)
+	}
+}
+
+func TestParseNonProxyLine(t *testing.T) {
+	reader := bufio.NewReader(strings.NewReader(noneProxyLine))
+	p, err := ConsumeProxyLine(reader)
+	if err != nil || p != nil {
+		t.Fatalf("Parsing none PROXY line failed. Expected nil, nil; got %q, %q\n", p, err)
+	}
+}
+
+func TestInvalidProxyLines(t *testing.T) {
+	for _, str := range invalidProxyLines {
+		reader := bufio.NewReader(strings.NewReader(str))
+		_, err := ConsumeProxyLine(reader)
+		if err == nil {
+			t.Fatalf("Parsing an invalid PROXY line %q fails to fail\n", str)
+		}
+	}
+}
+
+func (p *ProxyLine) EqualTo(q *ProxyLine) bool {
+	return p.Protocol == q.Protocol &&
+		p.SrcAddr.String() == q.SrcAddr.String() &&
+		p.DstAddr.String() == q.DstAddr.String() &&
+		p.SrcPort == q.SrcPort &&
+		p.DstPort == q.DstPort
+}

--- a/proxyprotocol/proxyline/proxy-protocol.txt
+++ b/proxyprotocol/proxyline/proxy-protocol.txt
@@ -1,0 +1,224 @@
+                               The PROXY protocol
+                                  Willy Tarreau
+                                    2011/03/20
+
+Abstract
+
+   The PROXY protocol provides a convenient way to safely transport connection
+   information such as a client's address across multiple layers of NAT or TCP
+   proxies. It is designed to require little changes to existing components and
+   to limit the performance impact caused by the processing of the transported
+   information.
+
+
+Revision history
+
+   2010/10/29 - first version
+   2011/03/20 - update: implementation and security considerations
+
+
+1. Background
+
+Relaying TCP connections through proxies generally involves a loss of the
+original TCP connection parameters such as source and destination addresses,
+ports, and so on. Some protocols make it a little bit easier to transfer such
+information. For SMTP, Postfix authors have proposed the XCLIENT protocol which
+received broad adoption and is particularly suited to mail exchanges. In HTTP,
+we have the non-standard but omnipresent X-Forwarded-For header which relays
+information about the original source address, and the less common
+X-Original-To which relays information about the destination address.
+
+However, both mechanisms require a knowledge of the underlying protocol to be
+implemented in intermediaries.
+
+Then comes a new class of products which we'll call "dumb proxies", not because
+they don't do anything, but because they're processing protocol-agnostic data.
+Stunnel is an example of such a "dumb proxy". It talks raw TCP on one side, and
+raw SSL on the other one, and does that reliably.
+
+The problem with such a proxy when it is combined with another one such as
+haproxy is to adapt it to talk the higher level protocol. A patch is available
+for Stunnel to make it capable to insert an X-Forwarded-For header in the first
+HTTP request of each incoming connection. Haproxy is able not to add another
+one when the connection comes from Stunnel, so that it's possible to hide it
+from the servers.
+
+The typical architecture becomes the following one :
+
+
+      +--------+      HTTP                      :80 +----------+
+      | client |  --------------------------------> |          |
+      |        |                                    | haproxy, |
+      +--------+             +---------+            |  1 or 2  |
+     /        /     HTTPS    | stunnel |  HTTP  :81 | listening|
+    <________/    ---------> | (server | ---------> |  ports   |
+                             |  mode)  |            |          |
+                             +---------+            +----------+
+
+
+The problem appears when haproxy runs with keep-alive on the side towards the
+client. The Stunnel patch will only add the X-Forwarded-For header to the first
+request of each connection and all subsequent requests will not have it. One
+solution could be to improve the patch to make it support keep-alive and parse
+all forwarded data, whether they're announced with a Content-Length or with a
+Transfer-Encoding, taking care of special methods such as HEAD which announce
+data without transfering them, etc... In fact, it would require implementing a
+full HTTP stack in Stunnel. It would then become a lot more complex, a lot less
+reliable and would not anymore be the "dumb proxy" that fits every purposes.
+
+In practice, we don't need to add a header for each request because we'll emit
+the exact same information every time : the information related to the client
+side connection. We could then cache that information in haproxy and use it for
+every other request. But that becomes dangerous and is still limited to HTTP
+only.
+
+Another approach would be to prepend each connection with a line reporting the
+characteristics of the other side's connection. This method is a lot simpler to
+implement, does not require any protocol-specific knowledge on either side, and
+completely fits the purpose. That's finally what we did with a small patch to
+Stunnel and another one to haproxy. We have called this protocol the PROXY
+protocol.
+
+
+2. The PROXY protocol
+
+The PROXY protocol's goal is to fill the receiver's internal structures with
+the information it could have found itself if it performed the accept from the
+client. Thus right now we're supporting the following :
+  - INET protocol and family (TCP over IPv4 or IPv6)
+  - layer 3 source and destination addresses
+  - layer 4 source and destination ports if any
+
+Unlike the XCLIENT protocol, the PROXY protocol was designed with limited
+extensibility in order to help the receiver parse it very fast, while keeping
+it human-readable for better debugging possibilities. So it consists in exactly
+the following block prepended before any data flowing from the dumb proxy to
+the next hop :
+
+  - a string identifying the protocol : "PROXY" ( \x50 \x52 \x4F \x58 \x59 )
+
+  - exactly one space : " " ( \x20 )
+
+  - a string indicating the proxied INET protocol and family. At the moment,
+    only "TCP4" ( \x54 \x43 \x50 \x34 ) for TCP over IPv4, and "TCP6"
+    ( \x54 \x43 \x50 \x36 ) for TCP over IPv6 are allowed. Unsupported or
+    unknown protocols must be reported with the name "UNKNOWN" ( \x55 \x4E \x4B
+    \x4E \x4F \x57 \x4E). The remaining fields of the line are then optional
+    and may be ignored, until the CRLF is found.
+
+  - exactly one space : " " ( \x20 )
+
+  - the layer 3 source address in its canonical format. IPv4 addresses must be
+    indicated as a series of exactly 4 integers in the range [0..255] inclusive
+    written in decimal representation separated by exactly one dot between each
+    other. Heading zeroes are not permitted in front of numbers in order to
+    avoid any possible confusion with octal numbers. IPv6 addresses must be
+    indicated as series of 4 hexadecimal digits (upper or lower case) delimited
+    by colons between each other, with the acceptance of one double colon
+    sequence to replace the largest acceptable range of consecutive zeroes. The
+    total number of decoded bits must exactly be 128. The advertised protocol
+    family dictates what format to use.
+
+  - exactly one space : " " ( \x20 )
+
+  - the layer 3 destination address in its canonical format. It is the same
+    format as the layer 3 source address and matches the same family.
+
+  - exactly one space : " " ( \x20 )
+
+  - the TCP source port represented as a decimal integer in the range
+    [0..65535] inclusive. Heading zeroes are not permitted in front of numbers
+    in order to avoid any possible confusion with octal numbers.
+
+  - exactly one space : " " ( \x20 )
+
+  - the TCP destination port represented as a decimal integer in the range
+    [0..65535] inclusive. Heading zeroes are not permitted in front of numbers
+    in order to avoid any possible confusion with octal numbers.
+
+  - the CRLF sequence ( \x0D \x0A )
+
+The receiver MUST be configured to only receive this protocol and MUST not try
+to guess whether the line is prepended or not. That means that the protocol
+explicitly prevents port sharing between public and private access. Otherwise
+it would become a big security issue. The receiver should ensure proper access
+filtering so that only trusted proxies are allowed to use this protocol. The
+receiver must wait for the CRLF sequence to decode the addresses in order to
+ensure they are complete. Any sequence which does not exactly match the
+protocol must be discarded and cause a connection abort. It is recommended
+to abort the connection as soon as possible to that the emitter notices the
+anomaly.
+
+If the announced transport protocol is "UNKNOWN", then the receiver knows that
+the emitter talks the correct protocol, and may or may not decide to accept the
+connection and use the real connection's parameters as if there was no such
+protocol on the wire.
+
+An example of such a line before an HTTP request would look like this (CR
+marked as "\r" and LF marked as "\n") :
+
+    PROXY TCP4 192.168.0.1 192.168.0.11 56324 443\r\n
+    GET / HTTP/1.1\r\n
+    Host: 192.168.0.11\r\n
+    \r\n
+
+For the emitter, the line is easy to put into the output buffers once the
+connection is established. For the receiver, once the line is parsed, it's
+easy to skip it from the input buffers.
+
+
+3. Implementations
+
+Haproxy 1.5 implements the PROXY protocol on both sides :
+  - the listening sockets accept the protocol when the "accept-proxy" setting
+    is passed to the "bind" keyword. Connections accepted on such listeners
+    will behave just as if the source really was the one advertised in the
+    protocol. This is true for logging, ACLs, content filtering, transparent
+    proxying, etc...
+
+  - the protocol may be used to connect to servers if the "send-proxy" setting
+    is present on the "server" line. It is enabled on a per-server basis, so it
+    is possible to have it enabled for remote servers only and still have local
+    ones behave differently. If the incoming connection was accepted with the
+    "accept-proxy", then the relayed information is the one advertised in this
+    connection's PROXY line.
+
+We have a patch available for recent versions of Stunnel that brings it the
+ability to be an emitter. The feature is called "sendproxy" there.
+
+The protocol is so simple that it is expected that other implementations will
+appear, especially in environments such as SMTP, IMAP, FTP, RDP where the
+client's address is an important piece of information for the server and some
+intermediaries.
+
+Proxy developers are encouraged to implement this protocol, because it will
+make their products much more transparent in complex infrastructures, and will
+get rid of a number of issues related to logging and access control.
+
+
+4. Security considerations
+
+The protocol was designed so as to be distinguishable from HTTP. It will not
+parse as a valid HTTP request and an HTTP request will not parse as a valid
+proxy request. That makes it easier to enfore its use certain connections.
+Implementers should be very careful about not trying to automatically detect
+whether they have to decode the line or not, but rather to only rely on a
+configuration parameter. Indeed, if the opportunity is left to a normal client
+to use the protocol, he will be able to hide his activities or make them appear
+as coming from someone else. However, accepting the line only from a number of
+known sources should be safe.
+
+
+5. Future developments
+
+It is possible that the protocol may slightly evolve to present other
+information such as the incoming network interface, or the origin addresses in
+case of network address translation happening before the first proxy, but this
+is not identified as a requirement right now. Suggestions on improvements are
+welcome.
+
+
+6. Contacts
+
+Please use w@1wt.eu to send any comments to the author.
+


### PR DESCRIPTION
Make tiny-ssl-reverse-proxy understand [the PROXY protocol](http://www.haproxy.org/download/1.5/doc/proxy-protocol.txt).

This means that we send the correct `X-Forwarded-For` when run behind a TCP
proxy and started with `-behind-tcp-proxy`. If the PROXY header is missing,
the connection will work as normal, so that testing within the internal
network works as normal without the PROXY header.

The PROXY protocol is used by ELB and HAProxy (and others) in TCP proxy mode
to indicate to an upstream client who the connecting client is. The upshot is
that we can avoid needing to configure the ELB to receive and transmit TLS
connections and terminate the SSL connections on our instances.

The main downside is that something like the implementation in this PR needs
to be in the thing which accepts the TCP connections.