### PR TITLE
Support HTTP2 with PROXY protocol

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "vendor/github.com/gorilla/websocket"]
 	path = vendor/github.com/gorilla/websocket
 	url = https://github.com/gorilla/websocket
+[submodule "vendor/golang.org/x/net"]
+	path = vendor/golang.org/x/net
+	url = https://github.com/golang/net

--- a/proxyprotocol/http.go
+++ b/proxyprotocol/http.go
@@ -5,6 +5,8 @@ import (
 	"net"
 	"net/http"
 	"time"
+
+	"golang.org/x/net/http2"
 )
 
 // Copied verbatim from net/http's server.go.
@@ -27,22 +29,34 @@ func (ln tcpKeepAliveListener) Accept() (c net.Conn, err error) {
 }
 
 func BehindTCPProxyListenAndServeTLS(srv *http.Server, certFile, keyFile string) error {
-	// Begin copied verbatim from net/http
+	// Begin copied almost verbatim from net/http
 	addr := srv.Addr
 	if addr == "" {
 		addr = ":https"
 	}
-	config := &tls.Config{}
-	if srv.TLSConfig != nil {
-		*config = *srv.TLSConfig
-	}
-	if config.NextProtos == nil {
-		config.NextProtos = []string{"http/1.1"}
+
+	// Ensure we don't modify *TLSConfig, in case it is reused.
+	srv.TLSConfig = cloneTLSClientConfig(srv.TLSConfig)
+
+	err := http2.ConfigureServer(srv, nil)
+	if err != nil {
+		return err
 	}
 
-	var err error
-	config.Certificates = make([]tls.Certificate, 1)
-	config.Certificates[0], err = tls.LoadX509KeyPair(certFile, keyFile)
+	foundHTTP1 := false
+	for _, proto := range srv.TLSConfig.NextProtos {
+		if proto == "http/1.1" {
+			foundHTTP1 = true
+			break
+		}
+	}
+
+	if !foundHTTP1 {
+		srv.TLSConfig.NextProtos = append(srv.TLSConfig.NextProtos, "http/1.1")
+	}
+
+	srv.TLSConfig.Certificates = make([]tls.Certificate, 1)
+	srv.TLSConfig.Certificates[0], err = tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {
 		return err
 	}
@@ -51,13 +65,13 @@ func BehindTCPProxyListenAndServeTLS(srv *http.Server, certFile, keyFile string)
 	if err != nil {
 		return err
 	}
-	// End copied verbatim from net/http
+	// End copied almost verbatim from net/http
 
 	// Wrap the listener with one understanding the PROXY protocol
 	var listener net.Listener
 	listener = tcpKeepAliveListener{ln.(*net.TCPListener)}
 	listener = NewListener(listener)
-	listener = tls.NewListener(listener, config)
+	listener = tls.NewListener(listener, srv.TLSConfig)
 	return srv.Serve(listener)
 }
 
@@ -79,4 +93,34 @@ func BehindTCPProxyListenAndServe(srv *http.Server) error {
 	// Wrap the listener with one understanding the PROXY protocol
 	listener := NewListener(tcpKeepAliveListener{ln.(*net.TCPListener)})
 	return srv.Serve(listener)
+}
+
+// cloneTLSClientConfig is like cloneTLSConfig but omits
+// the fields SessionTicketsDisabled and SessionTicketKey.
+// This makes it safe to call cloneTLSClientConfig on a config
+// in active use by a server.
+// COPIED FROM net/http/transport.go
+func cloneTLSClientConfig(cfg *tls.Config) *tls.Config {
+	if cfg == nil {
+		return &tls.Config{}
+	}
+	return &tls.Config{
+		Rand:                     cfg.Rand,
+		Time:                     cfg.Time,
+		Certificates:             cfg.Certificates,
+		NameToCertificate:        cfg.NameToCertificate,
+		GetCertificate:           cfg.GetCertificate,
+		RootCAs:                  cfg.RootCAs,
+		NextProtos:               cfg.NextProtos,
+		ServerName:               cfg.ServerName,
+		ClientAuth:               cfg.ClientAuth,
+		ClientCAs:                cfg.ClientCAs,
+		InsecureSkipVerify:       cfg.InsecureSkipVerify,
+		CipherSuites:             cfg.CipherSuites,
+		PreferServerCipherSuites: cfg.PreferServerCipherSuites,
+		ClientSessionCache:       cfg.ClientSessionCache,
+		MinVersion:               cfg.MinVersion,
+		MaxVersion:               cfg.MaxVersion,
+		CurvePreferences:         cfg.CurvePreferences,
+	}
 }


### PR DESCRIPTION
The implementation of BehindTCPProxyListenAndServeTLS meant that HTTP2 was
not supported.

Unfortunately this seems to be required because it isn't easy to interpose just
the TCP listener.

HTTP2 support was added in the very code path that we had to copy to
substitute the PROXY protocol listener.