### PR TITLE
Remove pre go-1.7 HTTP2 vendoring

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "vendor/github.com/gorilla/websocket"]
 	path = vendor/github.com/gorilla/websocket
 	url = https://github.com/gorilla/websocket
-[submodule "vendor/golang.org/x/net"]
-	path = vendor/golang.org/x/net
-	url = https://github.com/golang/net

--- a/proxyprotocol/http.go
+++ b/proxyprotocol/http.go
@@ -5,8 +5,6 @@ import (
 	"net"
 	"net/http"
 	"time"
-
-	"golang.org/x/net/http2"
 )
 
 // Copied verbatim from net/http's server.go.
@@ -38,23 +36,7 @@ func BehindTCPProxyListenAndServeTLS(srv *http.Server, certFile, keyFile string)
 	// Ensure we don't modify *TLSConfig, in case it is reused.
 	srv.TLSConfig = cloneTLSClientConfig(srv.TLSConfig)
 
-	err := http2.ConfigureServer(srv, nil)
-	if err != nil {
-		return err
-	}
-
-	foundHTTP1 := false
-	for _, proto := range srv.TLSConfig.NextProtos {
-		if proto == "http/1.1" {
-			foundHTTP1 = true
-			break
-		}
-	}
-
-	if !foundHTTP1 {
-		srv.TLSConfig.NextProtos = append(srv.TLSConfig.NextProtos, "http/1.1")
-	}
-
+	var err error
 	srv.TLSConfig.Certificates = make([]tls.Certificate, 1)
 	srv.TLSConfig.Certificates[0], err = tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {

--- a/proxyprotocol/http.go
+++ b/proxyprotocol/http.go
@@ -36,6 +36,8 @@ func BehindTCPProxyListenAndServeTLS(srv *http.Server, certFile, keyFile string)
 	// Ensure we don't modify *TLSConfig, in case it is reused.
 	srv.TLSConfig = cloneTLSClientConfig(srv.TLSConfig)
 
+	srv.TLSConfig.NextProtos = append(srv.TLSConfig.NextProtos, "h2")
+
 	var err error
 	srv.TLSConfig.Certificates = make([]tls.Certificate, 1)
 	srv.TLSConfig.Certificates[0], err = tls.LoadX509KeyPair(certFile, keyFile)


### PR DESCRIPTION
It was necessary in the past to enable HTTP2 and use the latest HTTP2
library, but go-1.7 ships a recent HTTP2 implementation.

This is done as part of the upgrade to go-1.7.